### PR TITLE
Making models part of release rather than bundled in package

### DIFF
--- a/changes/release-assets.misc
+++ b/changes/release-assets.misc
@@ -1,0 +1,11 @@
+Due to PyPi's upload limit of ~100MB, we cannot bundle pre-trained models along with the
+built package.
+We are now building a process for acquiring these models around an included function
+that will attempt to fetch the latest released models from GitHub releases.
+
+The method :func:`~facelift._data.download_data` should be a quick initial setup task
+when attempting to use this module.
+This task will download the necessary data to use the included detectors and encoders.
+
+More details about what is necessary for this release process is and should (in the
+future) be documented in the :mod:`facelift._data` module.

--- a/docs/source/facelift.rst
+++ b/docs/source/facelift.rst
@@ -89,3 +89,12 @@ Facelift Package
 
 .. automodule:: facelift.window
    :members:
+
+
+----
+
+``facelift._data``
+------------------
+
+.. automodule:: facelift._data
+   :members:

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -54,17 +54,58 @@ The ``dlib`` dependency will always need to be built when installing ``facelift`
 This requires that ``cmake`` is available on the system and doesn't build with any GPU
 support.
 
-.. note::
-   The size of the package is fairly large at ~90MB unpacked.
-   Since we bundle the ``dlib`` and ``resnet`` models along with the release, most of
-   what you are downloading are actually just trained models for face detection and
-   recognition.
 
-   Currently, we don't have the method for avoiding this installation as the core
-   functionality of the package depends on these models existing and being declared and
-   loaded in a specific way.
-   I have several ideas on how to separate the data from the code.
-   However, this isn't a huge concern to me for a ``v1.0.0`` release.
+.. _model-installation:
 
+Model Installation
+==================
+
+Due to PyPi's upload limits, we cannot bundle the associated landmark and ResNet models
+for face detection or face encoding.
+Similar to how other projects have dealt with this issue in the past, we have supplied a
+special module :mod:`~._data` to programmatically fetch the necessary pre-trained models
+for using this package.
+
+The :func:`~._data.download_data` function will attempt to fetch the models uploaded to
+the latest GitHub release.
+
+.. code-block:: python
+
+   from facelift._data import download_data
+   download_data()
+
+
+If for some reason we mess up and forget to upload the models to the GitHub release, you
+can manually specify the release tag using the ``release_tag`` parameter.
+This will attempt to fetch the models from a very release instead of the very latest.
+
+.. code-block:: python
+
+   from facelift._data import download_data
+   download_data(release_tag="v0.1.0")
+
+
+You can also see the basic download status written out to ``stdout`` by setting the
+``display_progress`` parameter to ``True``.
+
+.. code-block:: python
+
+   from facelift._data import download_data
+   download_data(display_progress=True)
+
+
+I would prefer to be able to bundle the models along with the package since we are
+building a project revolving around **very specific** feature models and frameworks
+(rather than providing an open-ended framework for face detection).
+However, this is just something we need to do to satisfy PyPi.
+
+.. important::
+   At the moment, the downloaded models will be placed in a ``data`` directory within
+   the ``facelift`` package.
+   This means that your system or virtual environment will contain the downloaded
+   models.
+   If you are interested in the absolute path that the downloaded models are being
+   written to, you should set the ``display_progress`` flag to ``True`` as we write out
+   where files are being stored.
 
 .. include:: ./gpu-support.rst

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,11 +11,17 @@
             <a href="https://pypi.org/project/facelift/" target="_blank">
                <img alt="Supported Versions" src="https://img.shields.io/pypi/pyversions/facelift.svg" />
             </a>
+            <a href="https://pypi.org/project/facelift/" target="_blank">
+               <img alt="PyPi Status" src="https://img.shields.io/pypi/status/facelift" />
+            </a>
+            <a href="https://github.com/stephen-bunn/facelift/" target="_blank">
+               <img alt="License" src="https://img.shields.io/github/license/stephen-bunn/facelift">
+            </a>
             <a href="https://github.com/stephen-bunn/facelift/actions?query=workflow%3A%22Test+Package%22" target="_blank">
-               <img alt="Test Status" src="https://github.com/stephen-bunn/facelift/workflows/Test%20Package/badge.svg" />
+               <img alt="Test Status" src="https://img.shields.io/github/workflow/status/stephen-bunn/facelift/Test%20Package" />
             </a>
             <a href="https://codecov.io/gh/stephen-bunn/facelift" target="_blank">
-               <img alt="Coverage" src="https://codecov.io/gh/stephen-bunn/facelift/branch/master/graph/badge.svg?token=xhhZQr8l76" />
+               <img alt="Coverage" src="https://img.shields.io/codecov/c/github/stephen-bunn/facelift?token=xhhZQr8l76" />
             </a>
             <a href="https://github.com/ambv/black" target="_blank">
                <img alt="Code Style: Black" src="https://img.shields.io/badge/code%20style-black-000000.svg" />
@@ -23,7 +29,6 @@
          </div>
       </div>
    </div>
-
 
 Several personal projects I've had in the past relied on some basic face feature
 detection either for face isolation, face state detection, or some kinds of perspective

--- a/docs/source/usage/detecting-faces.rst
+++ b/docs/source/usage/detecting-faces.rst
@@ -3,12 +3,17 @@ Detecting Faces
 
 Now onto the fun part.
 Face feature detection is powered by good ol' dlib_.
-As part of this package, we have bundled 3 pre-trained landmark models for face features
-each detecting various different face landmarks.
+As part of this package, we have provided 3 pre-trained landmark models for face
+features each detecting various different face landmarks.
+
+.. tip::
+   To learn how to acquire these models, please see the :ref:`model-installation`
+   documentation.
+
 The face features (interchangeably termed landmarks) we are able to detect are
 classified in the :class:`~.types.FaceFeature` enumeration.
 
-The included landmark models are programmatically provided through the following
+The landmark models are programmatically provided through the following
 :class:`~.detect.BaseLandmarkDetector` subclasses:
 
 - :class:`~.detect.BasicFaceDetector`
@@ -65,7 +70,7 @@ before attempting to perform detection).
 
    Detect Flow
 
-If you are finding that the bundled face landmark models are not as accurate as you
+If you are finding that the face landmark models we install are not as accurate as you
 require, you should look further into training your own landmark models for dlib_.
 **Note that this is not a trivial task.**
 
@@ -241,8 +246,7 @@ include the curvature and angle of the forehead.
    </video>
 
 
-The included model is not as heavily trained as the
-:class:`~.detect.PartialFaceDetector` so you may see some inconsistencies between the
-two detectors.
+This model is not as heavily trained as the :class:`~.detect.PartialFaceDetector`
+so you may see some inconsistencies between the two detectors.
 Regardless, with the inclusion of the :attr:`~.types.FaceFeature.FOREHEAD` feature, you
 get another dimension to work with that may be valuable for your use case.

--- a/docs/source/usage/recognizing-faces.rst
+++ b/docs/source/usage/recognizing-faces.rst
@@ -4,8 +4,7 @@ Recognizing Faces
 Recognition is performed by producing an :attr:`~.types.Encoding` for a detected face.
 This encoding is just an array of dimensions that *should* be pretty unique for that
 person's face.
-The encoding itself is produced by yet another bundled pre-trained model produced by
-dlib_.
+The encoding itself is produced by yet another pre-trained model produced by dlib_.
 This model is a ResNet_ model trained for producing identifiers for images of faces.
 There are other trained models for producing identifiers for detected faces, however we
 are only bundling the one produced and used by dlib_.
@@ -176,7 +175,11 @@ the best fit for each detected face my webcam stream.
 
 
 You can see that when we are printing results in the terminal, the score for my name is
-closer to ``0.0`` than the score we get for Terry.
+actually further from ``0.0`` than the score we get for Terry.
+This is because I'm actually subtracting from ``1.0`` in this recording which is
+something I forgot to remove and I'm too lazy to remake the recoding.
+You can ignore the numbers being written to ``stdout`` in this case as they contradict
+what you should be expecting from :meth:`~.encode.BaseEncoder.score_encoding`.
 
 .. raw:: html
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -215,6 +215,20 @@ test = ["pytest (>=3.6.0,<3.9.0 || >3.9.0,<3.9.1 || >3.9.1,<3.9.2 || >3.9.2)", "
 
 [[package]]
 category = "dev"
+description = "Python @deprecated decorator to deprecate old python classes, functions or methods."
+name = "deprecated"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.10"
+
+[package.dependencies]
+wrapt = ">=1.10,<2"
+
+[package.extras]
+dev = ["tox", "bumpversion (<1)", "sphinx (<2)", "PyTest (<5)", "PyTest-Cov (<2.6)", "pytest", "pytest-cov"]
+
+[[package]]
+category = "dev"
 description = "Distribution utilities"
 name = "distlib"
 optional = false
@@ -650,6 +664,22 @@ version = "2.2.0"
 
 [[package]]
 category = "dev"
+description = "Use the full Github API v3"
+name = "pygithub"
+optional = false
+python-versions = ">=3.5"
+version = "1.53"
+
+[package.dependencies]
+deprecated = "*"
+pyjwt = "*"
+requests = ">=2.14.0"
+
+[package.extras]
+integrations = ["cryptography"]
+
+[[package]]
+category = "dev"
 description = "Pygments is a syntax highlighting package written in Python."
 name = "pygments"
 optional = false
@@ -674,6 +704,19 @@ name = "pyinstrument-cext"
 optional = false
 python-versions = "*"
 version = "0.2.2"
+
+[[package]]
+category = "dev"
+description = "JSON Web Token implementation in Python"
+name = "pyjwt"
+optional = false
+python-versions = "*"
+version = "1.7.1"
+
+[package.extras]
+crypto = ["cryptography (>=1.4)"]
+flake8 = ["flake8", "flake8-import-order", "pep8-naming"]
+test = ["pytest (>=4.0.1,<5.0.0)", "pytest-cov (>=2.6.0,<3.0.0)", "pytest-runner (>=4.2,<5.0.0)"]
 
 [[package]]
 category = "dev"
@@ -1189,16 +1232,16 @@ python-versions = "*"
 version = "3.7.4.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "1.25.10"
+version = "1.25.11"
 
 [package.extras]
 brotli = ["brotlipy (>=0.6.0)"]
-secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
@@ -1233,6 +1276,14 @@ version = "0.5.1"
 
 [[package]]
 category = "dev"
+description = "Module for decorators, wrappers and monkey patching."
+name = "wrapt"
+optional = false
+python-versions = "*"
+version = "1.12.1"
+
+[[package]]
+category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
@@ -1248,7 +1299,7 @@ testing = ["jaraco.itertools", "func-timeout"]
 profile = []
 
 [metadata]
-content-hash = "c3edf8e2d279d61f7fe98dd36652b7c6a872734a7e8b8c3d08925d931593a6b9"
+content-hash = "42e8e8d481e81b5f2920bf375c8c0a79de23be9a6825e2343f5014c706f01e57"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -1432,6 +1483,10 @@ cryptography = [
     {file = "cryptography-3.1-cp38-cp38-win32.whl", hash = "sha256:fa7fbcc40e2210aca26c7ac8a39467eae444d90a2c346cbcffd9133a166bcc67"},
     {file = "cryptography-3.1-cp38-cp38-win_amd64.whl", hash = "sha256:548b0818e88792318dc137d8b1ec82a0ab0af96c7f0603a00bb94f896fbf5e10"},
     {file = "cryptography-3.1.tar.gz", hash = "sha256:26409a473cc6278e4c90f782cd5968ebad04d3911ed1c402fc86908c17633e08"},
+]
+deprecated = [
+    {file = "Deprecated-1.2.10-py2.py3-none-any.whl", hash = "sha256:a766c1dccb30c5f6eb2b203f87edd1d8588847709c78589e1521d769addc8218"},
+    {file = "Deprecated-1.2.10.tar.gz", hash = "sha256:525ba66fb5f90b07169fdd48b6373c18f1ee12728ca277ca44567a367d9d7f74"},
 ]
 distlib = [
     {file = "distlib-0.3.1-py2.py3-none-any.whl", hash = "sha256:8c09de2c67b3e7deef7184574fc060ab8a793e7adbb183d942c389c8b13c52fb"},
@@ -1666,6 +1721,10 @@ pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
     {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
+pygithub = [
+    {file = "PyGithub-1.53-py3-none-any.whl", hash = "sha256:8ad656bf79958e775ec59f7f5a3dbcbadac12147ae3dc42708b951064096af15"},
+    {file = "PyGithub-1.53.tar.gz", hash = "sha256:776befaddab9d8fddd525d52a6ca1ac228cf62b5b1e271836d766f4925e1452e"},
+]
 pygments = [
     {file = "Pygments-2.7.0-py3-none-any.whl", hash = "sha256:2df50d16b45b977217e02cba6c8422aaddb859f3d0570a88e09b00eafae89c6e"},
     {file = "Pygments-2.7.0.tar.gz", hash = "sha256:2594e8fdb06fef91552f86f4fd3a244d148ab24b66042036e64f29a291515048"},
@@ -1703,6 +1762,10 @@ pyinstrument-cext = [
     {file = "pyinstrument_cext-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:ef26fed4b80c409e26115e22382740917a2f3fc421f9eb9e23fa31b23ca57d2d"},
     {file = "pyinstrument_cext-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:3e2142eceb4e47274b7f1770fe85601094d24146813bbf00f0a37106b080d803"},
     {file = "pyinstrument_cext-0.2.2.tar.gz", hash = "sha256:f29e25f71d74c0415ca9310e5567fff0f5d29f4240a09a885abf8b0eed71cc5b"},
+]
+pyjwt = [
+    {file = "PyJWT-1.7.1-py2.py3-none-any.whl", hash = "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e"},
+    {file = "PyJWT-1.7.1.tar.gz", hash = "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1911,8 +1974,8 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
-    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
+    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
+    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
 ]
 virtualenv = [
     {file = "virtualenv-20.0.31-py2.py3-none-any.whl", hash = "sha256:e0305af10299a7fb0d69393d8f04cb2965dda9351140d11ac8db4e5e3970451b"},
@@ -1921,6 +1984,9 @@ virtualenv = [
 webencodings = [
     {file = "webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78"},
     {file = "webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923"},
+]
+wrapt = [
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "facelift"
-version = "0.1.0"
+version = "0.2.0"
 description = "A simple wrapper for face detection and recognition"
 authors = ["Stephen Bunn <stephen@bunn.io>"]
 maintainers = []
@@ -50,8 +50,7 @@ exclude = [
   ".pre-commit-config.yaml",
   ".readthedocs.yaml",
   "requirements*.txt",
-  "src/facelift/data/landmarks/*",
-  "src/facelift/data/encoders/*",
+  "src/facelift/data/**/*",
 ]
 
 [tool.poetry.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,14 @@ include = [
   "CHANGELOG.md",
   "CONTRIBUTING.rst",
   "CONTRIBUTING.md",
-  "src/facelift/data/*"
 ]
 exclude = [
   ".editorconfig",
   ".pre-commit-config.yaml",
   ".readthedocs.yaml",
   "requirements*.txt",
-  "src/facelift/data/encoders/*"
+  "src/facelift/data/landmarks/*",
+  "src/facelift/data/encoders/*",
 ]
 
 [tool.poetry.urls]
@@ -67,6 +67,7 @@ opencv-python = "^4.4.0"
 dlib = "^19.21.0"
 cached-property = "^1.5.2"
 typing-extensions = "^3.7.4"
+urllib3 = "^1.25.11"
 
 [tool.poetry.dev-dependencies]
 black = "^20.8b1"
@@ -97,6 +98,7 @@ sphinx-hoverxref = "^0.5b1"
 sphinx-autodoc-typehints = "^1.11.0"
 sphinx-rtd-theme = {git = "https://github.com/stephen-bunn/sphinx_rtd_theme", rev = "dracula-pro"}
 pyinstrument = "^3.2.0"
+pygithub = "^1.53"
 
 [tool.poetry.extras]
 profile = ["pyprof2calltree", "pyinstrument"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ line_length = 88
 indent = '    '
 multi_line_output = 3
 length_sort = 0
-known_third_party = attr,cached_property,colorama,cv2,dlib,hypothesis,invoke,numpy,pytest,sphinx_rtd_theme,toml,towncrier,typing_extensions
+known_third_party = attr,cached_property,colorama,cv2,dlib,github,hypothesis,invoke,numpy,pytest,sphinx_rtd_theme,toml,towncrier,typing_extensions,urllib3
 known_first_party = facelift
 include_trailing_comma = true
 

--- a/src/facelift/_data.py
+++ b/src/facelift/_data.py
@@ -100,7 +100,7 @@ def _download(
         raise ValueError(f"Failed to fetch data from {url!r}, {response.data!r}")
 
     total_size = response.getheaders().get("content-length")
-    if display_progress and total_size is None:
+    if display_progress and total_size is None:  # pragma: no cover
         print(
             f"Failed to determine Content-Length for {url!r}, "
             "download progress will not be reported"
@@ -109,7 +109,7 @@ def _download(
     current_size = 0
     for chunk in response.stream(chunk_size):
         current_size += len(chunk)
-        if display_progress:
+        if display_progress:  # pragma: no cover
             if total_size is None:
                 sys.stdout.write(f"\r{url!s} [{current_size} / ?]")
             else:
@@ -120,7 +120,7 @@ def _download(
 
         yield chunk
 
-    if display_progress:
+    if display_progress:  # pragma: no cover
         sys.stdout.write("\n")
 
     response.release_conn()
@@ -275,7 +275,8 @@ def download_data(
                 checksum_hash.update(chunk)
 
         checksum = checksum_hash.hexdigest()
-        sys.stdout.write(f"Downloaded {asset_url} to {asset_path} ({checksum})\n")
+        if display_progress:  # pragma: no cover
+            sys.stdout.write(f"Downloaded {asset_url} to {asset_path} ({checksum})\n")
 
         if validate and checksum != asset_checksum:
             raise ValueError(

--- a/src/facelift/_data.py
+++ b/src/facelift/_data.py
@@ -126,7 +126,7 @@ def _download(
     response.release_conn()
 
 
-def _get_latest_release_tag() -> str:
+def _get_latest_release_tag() -> Optional[str]:
     """Get the latest release's tag from GitHub.
 
     Returns:

--- a/src/facelift/_data.py
+++ b/src/facelift/_data.py
@@ -1,0 +1,254 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2020 Stephen Bunn <stephen@bunn.io>
+# ISC License <https://choosealicense.com/licenses/isc>
+
+"""Helpers for fetching the pre-trained models this project is built around.
+
+Due to the size of the models that we are building this project around, we need to fetch
+the models outside of the standard PyPi installation.
+The following methods handle building an asset manifest that should be released with
+each GitHub release.
+This asset manifest will then further inform the little downloading script we have
+provided where to find and place the assets in the installed package.
+
+Examples:
+    >>> from facelift._data import download_data
+    >>> download_data(display_progress=True)
+    https://... [123 / 456] 26.97%
+    Downloaded https://... to ./... (1234567890)
+"""
+
+import json
+import sys
+from hashlib import md5
+from io import BytesIO
+from pathlib import Path
+from typing import Dict, Generator, List, Optional, Tuple
+
+import urllib3
+
+BASE_PATH = Path(__file__).absolute().parent
+REPOSITORY_NAME = "stephen-bunn/facelift"
+MANIFEST_NAME = "data-manifest.json"
+LATEST_RELEASE_URL = f"https://api.github.com/repos/{REPOSITORY_NAME}/releases/latest"
+DOWNLOAD_URL_TEMPLATE = (
+    f"https://github.com/{REPOSITORY_NAME}/releases/download/"
+    "{release_tag}/{asset_name}"
+)
+DOWNLOAD_CHUNK_SIZE = 2 ** 12
+
+
+def _download(
+    url: str,
+    display_progress: bool = False,
+    chunk_size: int = DOWNLOAD_CHUNK_SIZE,
+) -> Generator[bytes, None, None]:
+    """Download the content of a URL iteratively.
+
+    Args:
+        url (str):
+            The URL to download content from.
+        display_progress (bool, optional):
+            Flag that will print basic progress updates of the download.
+            Defaults to False.
+        chunk_size (int, optional):
+            The size of chunks to read in the content.
+            Defaults to DOWNLOAD_CHUNK_SIZE.
+
+    Raises:
+        ValueError:
+            When we fail to fetch the given URL.
+
+    Yields:
+        Generator[bytes, None, None]:
+            A generator of bytes that are less than or equal to the defined chunk size.
+    """
+
+    http = urllib3.PoolManager()
+    response = http.request(
+        "GET", url, preload_content=False, headers={"User-Agent": "urllib3"}
+    )
+    if response.status not in (200,):
+        raise ValueError(f"Failed to fetch data from {url!r}, {response.data!r}")
+
+    total_size = response.getheaders().get("content-length")
+    if display_progress and total_size is None:
+        print(
+            f"Failed to determine Content-Length for {url!r}, "
+            "download progress will not be reported"
+        )
+
+    current_size = 0
+    for chunk in response.stream(chunk_size):
+        current_size += len(chunk)
+        if display_progress:
+            if total_size is None:
+                sys.stdout.write(f"\r{url!s} [{current_size} / ?]")
+            else:
+                sys.stdout.write(
+                    f"\r{url!s} [{current_size} / {total_size}] "
+                    f"{(total_size / current_size) * 100.0:.2f}%",
+                )
+
+        yield chunk
+
+    if display_progress:
+        sys.stdout.write("\n")
+
+    response.release_conn()
+
+
+def _get_latest_release_tag() -> str:
+    """Get the latest release's tag from GitHub.
+
+    Returns:
+        str: The latest release tag.
+    """
+
+    release_data = BytesIO()
+    for chunk in _download(LATEST_RELEASE_URL):
+        release_data.write(chunk)
+
+    release_data.seek(0)
+    release_content = json.loads(release_data.read())
+    return release_content.get("tag_name")
+
+
+def _build_manifest_url(release_tag: Optional[str] = None) -> str:
+    """Build a release's manifest download URL.
+
+    Args:
+        release_tag (Optional[str], optional):
+            The release tag of the manifest to fetch.
+            Defaults to None which will fetch the latest release.
+
+    Returns:
+        str: The release asset manifest URL.
+    """
+
+    if release_tag is None:
+        release_tag = _get_latest_release_tag()
+
+    return DOWNLOAD_URL_TEMPLATE.format(
+        release_tag=release_tag, asset_name=MANIFEST_NAME
+    )
+
+
+def build_manifest(
+    release_tag: str, *asset_filepaths: Path
+) -> Dict[str, Tuple[str, str]]:
+    """Build the manifest content for a proposed release and defined assets.
+
+    Args:
+        release_tag (str):
+            The release tag the manifest is being built for.
+
+    Raises:
+        FileNotFoundError:
+            When a given asset filepath does not exist.
+        ValueError:
+            When a checksum cannot be calculated for one of the given filepaths.
+
+    Returns:
+        Dict[str, Tuple[str, str]]: The manifest JSON-serializable dictionary
+    """
+
+    manifest = {}
+    for filepath in asset_filepaths:
+        if not filepath.is_file():
+            raise FileNotFoundError(f"No such file {filepath!s} exists")
+
+        relative_path = filepath.relative_to(BASE_PATH)
+        checksum = None
+        with filepath.open("rb") as file_handle:
+            checksum = md5(file_handle.read()).hexdigest()
+
+        if checksum is None:
+            raise ValueError(f"Failed to calculate checksum for {filepath!s}")
+
+        manifest[relative_path.as_posix()] = (
+            DOWNLOAD_URL_TEMPLATE.format(
+                release_tag=release_tag, asset_name=relative_path.name
+            ),
+            checksum,
+        )
+
+    return manifest
+
+
+def get_remote_manifest(
+    release_tag: Optional[str] = None,
+) -> Dict[str, Tuple[str, str]]:
+    """Get the manifest content from a GitHub release.
+
+    Args:
+        release_tag (Optional[str], optional):
+            The release tag of the manifest to fetch.
+            Defaults to None which fetches the latest release manifest.
+
+    Returns:
+        Dict[str, Tuple[str, str]]: The manifest JSON-serializable dictionary
+    """
+
+    manifest_data = BytesIO()
+    for chunk in _download(_build_manifest_url(release_tag=release_tag)):
+        manifest_data.write(chunk)
+
+    manifest_data.seek(0)
+    return json.loads(manifest_data.read())
+
+
+def download_data(
+    display_progress: bool = False,
+    release_tag: Optional[str] = None,
+    chunk_size: int = DOWNLOAD_CHUNK_SIZE,
+    validate: bool = True,
+):
+    """Download the data from a fetched remote release manifest.
+
+    Args:
+        display_progress (bool, optional):
+            Flag that indicates if you want to display the download progress for assets.
+            Defaults to False.
+        release_tag (Optional[str], optional):
+            The release tag of the assets you want to download.
+            Defaults to None which will fetch the latest release assets.
+        chunk_size (int, optional):
+            The chunk size to use when downloading assets.
+            Defaults to DOWNLOAD_CHUNK_SIZE.
+        validate (bool, optional):
+            If ``False``, will skip checksum validation for all downloaded assets.
+            Defaults to True.
+
+    Raises:
+        FileExistsError:
+            If a file already exists at one of the assets relative file locations.
+        ValueError:
+            If the downloaded assets fails checksum validation.
+    """
+
+    manifest = get_remote_manifest(release_tag=release_tag)
+    for relative_path, (asset_url, asset_checksum) in manifest.items():
+        asset_path = BASE_PATH.joinpath(relative_path)
+        if asset_path.is_file():
+            raise FileExistsError(f"File at {asset_path!s} already exists")
+
+        if not asset_path.parent.is_dir():
+            asset_path.parent.mkdir(parents=True)
+
+        checksum_hash = md5()
+        with asset_path.open("wb") as file_handle:
+            for chunk in _download(
+                asset_url, display_progress=display_progress, chunk_size=chunk_size
+            ):
+                file_handle.write(chunk)
+                checksum_hash.update(chunk)
+
+        checksum = checksum_hash.hexdigest()
+        sys.stdout.write(f"Downloaded {asset_url} to {asset_path} ({checksum})\n")
+
+        if validate and checksum != asset_checksum:
+            raise ValueError(
+                f"Downloaded asset at {asset_path!s} has invalid checksum "
+                f"(got {checksum!s}, expected {asset_checksum!s})"
+            )

--- a/src/facelift/_data.py
+++ b/src/facelift/_data.py
@@ -11,6 +11,34 @@ each GitHub release.
 This asset manifest will then further inform the little downloading script we have
 provided where to find and place the assets in the installed package.
 
+This helper utility currently expects the following of the GitHub release:
+
+1. A ``data-manifest.json`` is provided as a GitHub release asset.
+2. All models within the asset manifest are included as GitHub release assets.
+
+.. important::
+    The ``data-manifest.json`` must following the following structure:
+
+    .. code-block:: json
+
+        {
+            "relative filepath from package root for asset": [
+                "download url of asset",
+                "md5 hash of asset"
+            ]
+        }
+
+    As an example:
+
+    .. code-block:: json
+
+        {
+            "data/encoders/dlib_face_recognition_resnet_model_v1.dat": [
+                "https://github.com/stephen-bunn/facelift/releases/download/v0.1.0/dlib_face_recognition_resnet_model_v1.dat",
+                "2316b25ae80acf4ad9b620b00071c423"
+            ]
+        }
+
 Examples:
     >>> from facelift._data import download_data
     >>> download_data(display_progress=True)
@@ -142,6 +170,8 @@ def build_manifest(
     Args:
         release_tag (str):
             The release tag the manifest is being built for.
+        asset_filepaths (:class:`pathlib.Path`):
+            Multiple existing local asset filepaths.
 
     Raises:
         FileNotFoundError:

--- a/tasks/publish.py
+++ b/tasks/publish.py
@@ -1,0 +1,192 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2020 Stephen Bunn <stephen@bunn.io>
+# ISC License <https://choosealicense.com/licenses/isc>
+
+"""Contains Invoke task functions for package publishing."""
+
+import json
+import os
+import subprocess
+import sys
+from functools import lru_cache
+from pathlib import Path
+
+import invoke
+from github import Github, GithubException
+
+from .utils import report
+
+
+@lru_cache()
+def _get_access_token():
+    access_token = os.environ.get("GITHUB_ACCESS_TOKEN")
+    if not access_token:
+        while access_token is None or len(access_token) <= 0:
+            access_token = input("GitHub Access Token: ").strip()
+
+    return access_token
+
+
+def _get_dist_dirpath(ctx):
+    dirpath = Path(ctx.directory).joinpath("dist")
+    if not dirpath.is_dir():
+        dirpath.mkdir(parents=True)
+
+    return dirpath
+
+
+def _get_github(ctx):
+    return Github(_get_access_token())
+
+
+def _get_repo(ctx):
+    return _get_github(ctx).get_user().get_repo(ctx.package.name)
+
+
+def _verify_release_new(ctx, release_tag):
+    try:
+        if _get_repo(ctx).get_release(release_tag):
+            message = f"release {release_tag} already exists on GitHub"
+            report.error(ctx, "publish.github", message)
+            raise ValueError(message)
+    except GithubException:
+        report.debug(
+            ctx,
+            "publish.github",
+            f"release {release_tag} does not already exist on GitHub",
+        )
+
+
+def _verify_commit_exists(ctx, commit_sha):
+    try:
+        if _get_repo(ctx).get_commit(commit_sha):
+            report.debug(
+                ctx,
+                "publish.github",
+                f"found local commit to be tagged ({commit_sha}) on GitHub",
+            )
+    except GithubException:
+        message = f"commit to be tagged ({commit_sha}) is not present on GitHub"
+        report.error(ctx, "publish.github", message)
+        raise ValueError(message)
+
+
+def _create_manifest(ctx, release_tag):
+    from facelift._data import BASE_PATH, MANIFEST_NAME, build_manifest
+
+    report.debug(ctx, "publish.github", "building asset manifest")
+    data_filepaths = [
+        asset for asset in BASE_PATH.joinpath("data").glob("**/*") if asset.is_file()
+    ]
+    manifest = build_manifest(release_tag, *data_filepaths)
+    manifest_filepath = _get_dist_dirpath(ctx).joinpath(MANIFEST_NAME)
+
+    report.debug(
+        ctx,
+        "publish.github",
+        f"writing asset manifest to {manifest_filepath}",
+    )
+    with manifest_filepath.open("w") as file_handle:
+        json.dump(manifest, file_handle)
+
+    return manifest, manifest_filepath
+
+
+def _create_tag(ctx, release_tag, release_name, commit_sha, draft=False):
+    report.info(
+        ctx,
+        "publish.github",
+        f"creating release tag {release_tag} on commit {commit_sha}",
+    )
+
+    if not draft:
+        return _get_repo(ctx).create_git_tag(
+            tag=release_tag,
+            tag_message=release_name,
+            object=commit_sha,
+            type="commit",
+        )
+
+
+def _create_release(ctx, release_tag, release_name, release_message, draft=False):
+    report.info(
+        ctx,
+        "publish.github",
+        f"creating release {release_name!r} on tag {release_tag}",
+    )
+
+    if not draft:
+        return _get_repo(ctx).create_git_release(
+            tag=release_tag,
+            name=release_name,
+            message=release_message,
+        )
+
+
+def _get_release_assets(ctx, manifest):
+    dist_dirpath = _get_dist_dirpath(ctx)
+    dist_assets = [asset for asset in dist_dirpath.iterdir() if asset.is_file()]
+    manifest_assets = [
+        dist_dirpath.joinpath(relative_path) for relative_path in manifest.keys()
+    ]
+
+    return dist_assets + manifest_assets
+
+
+def _upload_release_assets(ctx, release, asset_filepaths, draft=False):
+    uploaded_assets = []
+
+    for filepath in asset_filepaths:
+        report.info(ctx, "publish.github", f"uploading asset {filepath}")
+        if not draft:
+            uploaded_assets.append(release.upload_asset(filepath.as_posix()))
+
+    return uploaded_assets
+
+
+@invoke.task()
+def github(ctx, draft=False):
+    """Publish the latest pushed commit as a release to GitHub."""
+
+    release_tag = f"v{ctx.version!s}"
+    release_name = f"Release {release_tag!s}"
+    _verify_release_new(ctx, release_tag)
+
+    local_commit_sha = (
+        subprocess.run(["git", "rev-parse", "HEAD"], capture_output=True)
+        .stdout.decode("utf-8")
+        .strip()
+    )
+    _verify_commit_exists(ctx, local_commit_sha)
+
+    manifest, manifest_filepath = _create_manifest(ctx, release_tag)
+    _create_tag(ctx, release_tag, release_name, local_commit_sha, draft=draft)
+    release = _create_release(ctx, release_tag, release_name, "", draft=draft)
+
+    release_assets = _get_release_assets(ctx, manifest)
+    _upload_release_assets(ctx, release, release_assets, draft=draft)
+
+    if not draft:
+        report.success(
+            ctx,
+            "publish.github",
+            f"published release {release_tag} to GitHub <{release.html_url}>",
+        )
+
+    report.debug(
+        ctx,
+        "publish.github",
+        f"removing asset manifest at {manifest_filepath} before PyPi publish",
+    )
+    os.remove(manifest_filepath.as_posix())
+
+
+@invoke.task()
+def pypi(ctx, draft=False):
+    """Publish existing distributables to PyPi."""
+
+    report.info(ctx, "publish.pypi", "uploading dist to PyPi")
+
+    if not draft:
+        ctx.run("poetry publish")
+        report.success(ctx, "publish.pypi", "published to PyPi")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,14 +5,63 @@
 """Contains tests related to the _data module."""
 
 import json
+import shutil
 import string
-from typing import Dict, Optional
-from unittest.mock import patch
+from hashlib import md5
+from pathlib import Path
+from tempfile import NamedTemporaryFile, TemporaryDirectory
+from typing import Dict, Generator, List, Optional
+from unittest.mock import ANY, call, patch
 
+import pytest
 from hypothesis import given
-from hypothesis.strategies import dictionaries, none, one_of, text
+from hypothesis.strategies import (
+    binary,
+    dictionaries,
+    integers,
+    lists,
+    none,
+    one_of,
+    text,
+)
 
 from facelift import _data
+
+from .strategies import image_path, pathlib_path
+
+
+@given(text(string.ascii_letters + string.digits))
+def test_download_raises_ValueError_when_status_non_200(url: str):
+    with patch("facelift._data.urllib3") as mocked_urllib3:
+        mocked_urllib3.PoolManager.return_value.request.return_value.status = 400
+
+        with pytest.raises(ValueError):
+            next(_data._download(url))
+
+
+@given(
+    text(string.ascii_letters + string.digits),
+    lists(binary(min_size=1), min_size=1, unique=True),
+    integers(min_value=1),
+)
+def test_download(url: str, data: List[bytes], chunk_size: int):
+    with patch("facelift._data.urllib3") as mocked_urllib3:
+        mocked_http = mocked_urllib3.PoolManager.return_value
+        mocked_response = mocked_http.request.return_value
+        mocked_response.status = 200
+        mocked_response.stream.return_value = iter(data)
+
+        content = list(_data._download(url, chunk_size=chunk_size))
+        mocked_http.request.assert_called_once_with(
+            "GET",
+            url,
+            preload_content=False,
+            headers=ANY,
+        )
+        mocked_response.stream.assert_has_calls([call(chunk_size)])
+        mocked_http.request.return_value.release_conn.assert_called_once()
+
+        assert content == data
 
 
 @given(text(string.ascii_letters + string.digits))
@@ -46,6 +95,42 @@ def test_build_manifest_url(release_tag: Optional[str]):
             )
 
 
+@given(text(string.printable), pathlib_path())
+def test_build_manifest_raises_FileNotFoundError_with_missing_filepath(
+    releases_tag: str, filepath: Path
+):
+    with pytest.raises(FileNotFoundError):
+        _data.build_manifest(releases_tag, *[filepath])
+
+
+@given(text(string.printable))
+def test_build_manifest_raises_ValueError_when_checksum_fails(release_tag: str):
+    filepaths = list(path for path in _data.BASE_PATH.iterdir() if path.is_file())
+    with patch("facelift._data.md5") as mocked_md5:
+        mocked_md5.return_value.hexdigest.return_value = None
+
+        with pytest.raises(ValueError):
+            _data.build_manifest(release_tag, *filepaths)
+
+
+@given(text(string.ascii_letters + string.digits))
+def test_build_manifest(release_tag: str):
+    filepaths = list(path for path in _data.BASE_PATH.iterdir() if path.is_file())
+    manifest = _data.build_manifest(release_tag, *filepaths)
+
+    assert isinstance(manifest, dict)
+    assert len(manifest) == len(filepaths)
+    for relative_path, (download_url, checksum) in manifest.items():
+        assert isinstance(relative_path, str)
+        asset_filepath = _data.BASE_PATH.joinpath(relative_path)
+        assert asset_filepath.is_file()
+
+        with asset_filepath.open("rb") as file_handle:
+            assert md5(file_handle.read()).hexdigest() == checksum
+
+        assert isinstance(download_url, str)
+
+
 @given(
     dictionaries(
         text(string.ascii_letters + string.digits),
@@ -63,3 +148,98 @@ def test_get_remote_manifest(manifest_data: Dict[str, str], release_tag: Optiona
         mocked_build_manifest_url.assert_called_once_with(release_tag=release_tag)
 
         assert remote_manifest == manifest_data
+
+
+@given(text(string.printable))
+def test_download_data_raises_FileExistsError_if_file_location_already_exists(
+    release_tag: str,
+):
+    with patch("facelift._data.get_remote_manifest") as mocked_get_remote_manifest:
+        mocked_get_remote_manifest.return_value = _data.build_manifest(
+            release_tag, *[next(_data.BASE_PATH.iterdir())]
+        )
+
+        with pytest.raises(FileExistsError):
+            _data.download_data()
+
+
+@given(text(string.printable), lists(binary(min_size=1), min_size=1))
+def test_download_data_raise_ValueError_if_checksum_mismatch(
+    release_tag: str, data: List[bytes]
+):
+    manifest = _data.build_manifest(release_tag, *[next(_data.BASE_PATH.iterdir())])
+    with TemporaryDirectory(prefix="facelift-test") as temp_dir:
+        temp_dirpath = Path(temp_dir)
+
+        with patch(
+            "facelift._data.get_remote_manifest"
+        ) as mocked_get_remote_manifest, patch(
+            "facelift._data._download"
+        ) as mocked_download, patch(
+            "facelift._data.md5"
+        ) as mocked_md5, patch(
+            "facelift._data.BASE_PATH", temp_dirpath
+        ):
+            mocked_get_remote_manifest.return_value = manifest
+            mocked_download.return_value = iter(data)
+            mocked_md5.return_value.hexdigest.return_value = "not-an-md5-checksum"
+
+            with pytest.raises(ValueError):
+                _data.download_data(validate=True)
+
+
+@given(text(string.printable))
+def test_download_data(release_tag: str):
+    def _chunk_bytes(source: bytes, size: int) -> Generator[bytes, None, None]:
+        for index in range(0, len(source), size):
+            yield source[index : index + size]
+
+    manifest_asset: Path = next(_data.BASE_PATH.iterdir())
+    manifest = _data.build_manifest(release_tag, *[manifest_asset])
+
+    # here we are inserting the /test directory between the asset and the actual
+    # temporary directory to ensure that we are testing that the download_data will
+    # create missing parent directories if necessary
+    manifest_key = list(manifest.keys())[0]
+    manifest_key_path = Path(manifest_key)
+    manifest_testing_key = (
+        manifest_key_path.parent.joinpath("test")
+        .joinpath(manifest_key_path.name)
+        .as_posix()
+    )
+
+    # forceably update the current manifest asset key with the new testing key to test
+    # parent directory creation
+    manifest[manifest_testing_key] = manifest[manifest_key]
+    del manifest[manifest_key]
+
+    with TemporaryDirectory(prefix="facelift-test") as temp_dir, NamedTemporaryFile(
+        dir=temp_dir
+    ) as temp_file:
+        temp_dirpath = Path(temp_dir)
+        temp_filepath = Path(temp_file.name)
+        shutil.copy(manifest_asset, temp_filepath)
+
+        with patch(
+            "facelift._data.get_remote_manifest"
+        ) as mocked_get_remote_manifest, patch(
+            "facelift._data._download"
+        ) as mocked_download, patch(
+            "facelift._data.BASE_PATH", temp_dirpath
+        ):
+            mocked_get_remote_manifest.return_value = manifest
+            with temp_filepath.open("rb") as file_handle:
+                mocked_download.return_value = _chunk_bytes(
+                    file_handle.read(), _data.DOWNLOAD_CHUNK_SIZE
+                )
+
+            _data.download_data(validate=True)
+            assert temp_dirpath.joinpath(manifest_testing_key).is_file()
+
+            with manifest_asset.open("rb") as manifest_file_handle, temp_filepath.open(
+                "rb"
+            ) as temp_file_handle:
+                assert (
+                    md5(manifest_file_handle.read()).digest()
+                    == md5(temp_file_handle.read()).digest()
+                )

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,0 +1,65 @@
+# -*- encoding: utf-8 -*-
+# Copyright (c) 2020 Stephen Bunn <stephen@bunn.io>
+# ISC License <https://choosealicense.com/licenses/isc>
+
+"""Contains tests related to the _data module."""
+
+import json
+import string
+from typing import Dict, Optional
+from unittest.mock import patch
+
+from hypothesis import given
+from hypothesis.strategies import dictionaries, none, one_of, text
+
+from facelift import _data
+
+
+@given(text(string.ascii_letters + string.digits))
+def test_get_latest_release_tag(release_tag: Optional[str]):
+    with patch("facelift._data._download") as mocked_download:
+        mocked_download.return_value = iter(
+            [bytes(f'{{"tag_name": "{release_tag}"}}', "utf-8")]
+        )
+
+        release_tag = _data._get_latest_release_tag()
+        mocked_download.assert_called_once_with(_data.LATEST_RELEASE_URL)
+        assert release_tag == release_tag
+
+
+@given(one_of(text(string.printable), none()))
+def test_build_manifest_url(release_tag: Optional[str]):
+    with patch(
+        "facelift._data._get_latest_release_tag"
+    ) as mocked_get_latest_release_tag:
+        mocked_get_latest_release_tag.return_value = "test"
+
+        if release_tag is None:
+            assert _data._build_manifest_url() == _data.DOWNLOAD_URL_TEMPLATE.format(
+                release_tag="test", asset_name=_data.MANIFEST_NAME
+            )
+        else:
+            assert _data._build_manifest_url(
+                release_tag
+            ) == _data.DOWNLOAD_URL_TEMPLATE.format(
+                release_tag=release_tag, asset_name=_data.MANIFEST_NAME
+            )
+
+
+@given(
+    dictionaries(
+        text(string.ascii_letters + string.digits),
+        text(string.ascii_letters + string.digits),
+    ),
+    one_of(text(string.printable), none()),
+)
+def test_get_remote_manifest(manifest_data: Dict[str, str], release_tag: Optional[str]):
+    with patch("facelift._data._download") as mocked_download, patch(
+        "facelift._data._build_manifest_url"
+    ) as mocked_build_manifest_url:
+        mocked_download.return_value = iter([bytes(json.dumps(manifest_data), "utf-8")])
+
+        remote_manifest = _data.get_remote_manifest(release_tag=release_tag)
+        mocked_build_manifest_url.assert_called_once_with(release_tag=release_tag)
+
+        assert remote_manifest == manifest_data

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -19,7 +19,7 @@ from unittest.mock import ANY, patch
 import cv2
 import numpy
 import pytest
-from hypothesis import given, settings
+from hypothesis import HealthCheck, given, settings
 from hypothesis.strategies import (
     SearchStrategy,
     composite,
@@ -147,6 +147,7 @@ def test_get_normalized_frame(filepath: Path, size: int, offset: float):
             assert result.shape == (size, size, 3)
 
 
+@settings(suppress_health_check=[HealthCheck.too_slow])
 @given(frame(), face_with_eyes())
 def test_get_normalized_frame_uses_defaults(test_frame: Frame, test_face: Face):
     with patch("facelift.helpers.cv2") as mocked_cv2, patch(


### PR DESCRIPTION
## Summary

Instead of bundling the pre-trained models along with the package and fighting with PyPi upload limits. We are opting for a more sustainable release pattern by supplying the models as part of the GitHub release assets. A new module `_data` with the provided `download_data` function will handle fetching the latest released models from GitHub.

## User Experience

This can be seen as an annoyance since a new setup setup step is necessary for installing the models before you can get started working with the package.

## Risks and Caveats

A new `release` task has been added to avoid running into the situation where were *forget* to add the packages to the GitHub release. This new task should be used to build and publish any new releases. 

## Education

Education related materials about this new process have been added to the documentation.

## PR Checklist

- [x]  I am merging from a `feature/`, `bugfix/`, `hotfix/`, etc. prefixed branch 🌱
- [x]  I made sure to add a news fragment for the changes proposed 🗞
- ~~[ ]  I made sure to add [closing keywords](https://help.github.com/en/articles/closing-issues-using-keywords) to close related issues 👍~~
- [x]  I made sure to drink a glass of water 🥛

**Thanks!** ❤️
